### PR TITLE
Add custom var lsp-php-server-development-checkout

### DIFF
--- a/lsp-php.el
+++ b/lsp-php.el
@@ -19,7 +19,17 @@
 ;;;###autoload
 (defcustom lsp-php-server-install-dir (file-truename (locate-user-emacs-file "php-language-server/"))
   "Install directory for php-language-server.
-The slash is expected at the end."
+
+It should include a trailing slash."
+  :group 'lsp-mode
+  :risky t
+  :type 'directory)
+
+;;;###autoload
+(defcustom lsp-php-server-development-checkout nil
+  "If set, the path to a user's development checkout of php-language-server.
+
+It should include a trailing slash."
   :group 'lsp-mode
   :risky t
   :type 'directory)
@@ -28,6 +38,11 @@ The slash is expected at the end."
   "Lsp php command."
   (let ((php-language-server-file
 	 (concat lsp-php-server-install-dir "vendor/felixfbecker/language-server/bin/php-language-server.php")))
+
+	(when lsp-php-server-development-checkout
+	  (setq php-language-server-file
+			(concat lsp-php-server-development-checkout "bin/php-language-server.php")))
+
     `("php"
       ,php-language-server-file)))
 


### PR DESCRIPTION
I track the development version of the php-language-server and had been
using it with Emacs and my own unfinished lsp-php extension for a while.

With this change, I can use this package to do that.

It's useful if you want to keep up with the bleeding edge or if you want to actually hack on php-language-server yourself.